### PR TITLE
fix memory leak on macOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,8 +24,8 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final _textureRgbaRendererPlugin = TextureRgbaRenderer();
   int textureId = -1;
-  int height = 500;
-  int width = 500;
+  int height = 768;
+  int width = 1377;
   int cnt = 0;
   var key = 0;
   int texturePtr = 0;
@@ -62,6 +62,7 @@ class _MyAppState extends State<MyApp> {
     method = methodId;
     final rowBytes = (width * 4 + strideAlign - 1) & (~(strideAlign - 1));
     final picDataLength = rowBytes * height;
+    debugPrint('REMOVE ME =============================== rowBytes $rowBytes');
     _timer?.cancel();
     // 60 fps
     _timer =
@@ -142,8 +143,8 @@ class _MyAppState extends State<MyApp> {
       final r = index / rowBytes;
       final c = (index % rowBytes) / 4;
       final p = index & 0x03;
-      final edgeH = (c >= 0 && c < 10) || ((c >= height - 10) && c < height);
-      final edgeW = (r >= 0 && r < 10) || ((r >= width - 10) && r < width);
+      final edgeH = (c >= 0 && c < 10) || ((c >= width - 10) && c < width);
+      final edgeW = (r >= 0 && r < 10) || ((r >= height - 10) && r < height);
       if (edgeH || edgeW) {
         if (p == 0 || p == 3) {
           return 255;

--- a/macos/Classes/TextureRgbaApi.m
+++ b/macos/Classes/TextureRgbaApi.m
@@ -15,8 +15,7 @@ extern "C" {
 /// Keep the same name with Windows.
 void FlutterRgbaRendererPluginOnRgba(void* texture_rgba_ptr, const uint8_t* buffer, int len, int width, int height, int stride_align) {
     TextRgba* texture_rgba = (__bridge TextRgba *)(texture_rgba_ptr);
-    NSData* data = [NSData dataWithBytesNoCopy:(void*)buffer length:len freeWhenDone:FALSE];
-    [texture_rgba markFrameAvaliableWithData:data width:width height:height stride_align: stride_align];
+    [texture_rgba markFrameAvaliableRawWithBuffer:buffer len:len width:width height:height stride_align: stride_align];
 }
 
 #if __cplusplus


### PR DESCRIPTION
Memory leak.

```obj-c
void FlutterRgbaRendererPluginOnRgba(void* texture_rgba_ptr, const uint8_t* buffer, int len, int width, int height, int stride_align) {
    TextRgba* texture_rgba = (__bridge TextRgba *)(texture_rgba_ptr);
    NSData* data = [NSData dataWithBytesNoCopy:(void*)buffer length:len freeWhenDone:FALSE];
    [texture_rgba markFrameAvaliableWithData:data width:width height:height stride_align: stride_align];
}
```

`markFrameAvaliable` creates a copy of NsData object and never free the buffer in the object.